### PR TITLE
Included rapidjson as submodule and added an .m file to build .oct files directly within Octave on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 *.o
 *.oct
-rapidjson/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "rapidjson"]
+	path = rapidjson
+	url = https://github.com/Tencent/rapidjson.git

--- a/build.m
+++ b/build.m
@@ -1,0 +1,2 @@
+mkoctfile -Wall -Wextra -I./rapidjson/include load_json.cc
+mkoctfile -Wall -Wextra -I./rapidjson/include save_json.cc


### PR DESCRIPTION
To simplify building octave-rapidjson on windows, using octave connected .oct compiler